### PR TITLE
Use frontend base URL for chatbot links

### DIFF
--- a/ecommerce/src/main/java/com/marketplace/ecommerce/chatbot/service/impl/ChatbotServiceImpl.java
+++ b/ecommerce/src/main/java/com/marketplace/ecommerce/chatbot/service/impl/ChatbotServiceImpl.java
@@ -62,14 +62,14 @@ public class ChatbotServiceImpl implements ChatbotService {
     private final OrderRepository orderRepository;
     private final SimpMessagingTemplate messagingTemplate;
 
-    @Value("${app.base-url:http://localhost:8080}")
-    private String baseUrl;
+    // Base URL for frontend links returned by chatbot (product detail, etc.)
+    @Value("${app.frontend.base-url:http://localhost:5173}")
+    private String frontendBaseUrl;
 
     @Override
     @Transactional(readOnly = true)
     public ChatbotResponse init(HttpSession session, CurrentUserInfo principal) {
         String current = (String) session.getAttribute(SESSION_CURRENT_NODE);
-        String root = (String) session.getAttribute(SESSION_ROOT_NODE);
         String roleContext = getRoleContext(principal);
         String rootNodeId = getRootNodeId(roleContext);
 
@@ -452,9 +452,10 @@ public class ChatbotServiceImpl implements ChatbotService {
         String thumb = null;
         if (p.getImages() != null && !p.getImages().isEmpty() && p.getImages().get(0).getImageUrl() != null) {
             String url = p.getImages().get(0).getImageUrl();
-            thumb = url.startsWith("http") ? url : baseUrl + (url.startsWith("/") ? url : "/" + url);
+            // Keep absolute URLs (MinIO/CDN). For relative paths (if any), prefix with backend base.
+            thumb = url.startsWith("http") ? url : frontendBaseUrl + (url.startsWith("/") ? url : "/" + url);
         }
-        String productUrl = baseUrl + "/products/" + p.getId();
+        String productUrl = frontendBaseUrl + "/products/" + p.getId();
         return ChatbotProductCardResponse.builder()
                 .id(p.getId())
                 .name(p.getName())

--- a/ecommerce/src/main/resources/application.properties
+++ b/ecommerce/src/main/resources/application.properties
@@ -47,6 +47,9 @@ ghn.shop-id=${GHN_SHOP_ID}
 # WebSocket (SockJS) allowed origins for live chat. Comma-separated.
 app.websocket.allowed-origins=http://localhost:5173,http://127.0.0.1:5173,http://localhost:3000,http://127.0.0.1:3000
 
+# Frontend base URL used to generate links in chatbot responses (e.g. product detail link)
+app.frontend.base-url=http://localhost:5173
+
 # Ollama (embedding for recommendation). Optional: nếu không chạy Ollama thì recommendation vẫn chạy, embedding = null.
 app.ollama.base-url=http://localhost:11434
 app.ollama.embed-model=nomic-embed-text


### PR DESCRIPTION
Rename backend baseUrl to frontendBaseUrl and use it to build product/detail links returned by the chatbot. Default changed to http://localhost:5173 and property app.frontend.base-url was added to application.properties. Image handling now preserves absolute URLs (CDN/MinIO) and prefixes relative image paths with the frontend base; product URLs are generated using the frontend base as well. Also removed an unused session root retrieval in init().